### PR TITLE
Updated provider version & Tags syntax

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Configure the AWS Provider
 provider "aws" {
-  version = "1.60.0"
+  version = "2.57.0"
   region = "${var.region}"
 }
 

--- a/tfmodules/nodes/main.tf
+++ b/tfmodules/nodes/main.tf
@@ -53,7 +53,7 @@ resource "aws_instance" "master" {
   vpc_security_group_ids = ["${aws_security_group.nodes.id}"]
   subnet_id              = "${var.subnet_id}"
 
-  tags {
+  tags = {
     Name = "${var.name}-master"
   }
 
@@ -93,7 +93,7 @@ resource "aws_instance" "slave" {
   vpc_security_group_ids = ["${aws_security_group.nodes.id}"]
   subnet_id              = "${var.subnet_id}"
 
-  tags {
+  tags = {
     Name = "${var.name}-slave"
   }
 


### PR DESCRIPTION
Reconciling

```
➜  locust-terraform-stack git:(master) terraform providers
.
├── provider.aws 1.60.0
├── module.networking
│   └── provider.aws ~> 2.57
└── module.nodes
    ├── provider.aws (inherited)
    └── provider.tls
```

and 

```
Error: Unsupported block type

  on tfmodules/nodes/main.tf line 56, in resource "aws_instance" "master":
  56:   tags {
```

to successfully terraform plan